### PR TITLE
stretch: fix install file symlinks

### DIFF
--- a/debian/stretch/debian/libignition-fuel-tools2-dev.install
+++ b/debian/stretch/debian/libignition-fuel-tools2-dev.install
@@ -1,1 +1,0 @@
-../../../ubuntu/debian/libignition-fuel-tools2-dev.install

--- a/debian/stretch/debian/libignition-fuel-tools2.install
+++ b/debian/stretch/debian/libignition-fuel-tools2.install
@@ -1,1 +1,0 @@
-../../../ubuntu/debian/libignition-fuel-tools2.install

--- a/debian/stretch/debian/libignition-fuel-tools3-dev.install
+++ b/debian/stretch/debian/libignition-fuel-tools3-dev.install
@@ -1,0 +1,1 @@
+../../../ubuntu/debian/libignition-fuel-tools3-dev.install

--- a/debian/stretch/debian/libignition-fuel-tools3.install
+++ b/debian/stretch/debian/libignition-fuel-tools3.install
@@ -1,0 +1,1 @@
+../../../ubuntu/debian/libignition-fuel-tools3.install


### PR DESCRIPTION
[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-fuel-tools3-debbuilder&build=447)](https://build.osrfoundation.org/job/ign-fuel-tools3-debbuilder/447/) https://build.osrfoundation.org/job/ign-fuel-tools3-debbuilder/447/

~~~
cp: cannot stat '/tmp/ign-fuel-tools3-release/debian/stretch//debian/libignition-fuel-tools2-dev.install': No such file or directory
cp: cannot stat '/tmp/ign-fuel-tools3-release/debian/stretch//debian/libignition-fuel-tools2.install': No such file or directory
~~~